### PR TITLE
Refine taxonomy term validation

### DIFF
--- a/app/Domains/Taxonomy/Validators/TaxonomyTermMetadataValidator.php
+++ b/app/Domains/Taxonomy/Validators/TaxonomyTermMetadataValidator.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Domains\Taxonomy\Validators;
+
+use App\Domains\Taxonomy\Models\Taxonomy;
+use Illuminate\Support\Facades\Validator;
+
+class TaxonomyTermMetadataValidator
+{
+    public function validate(array $metadata, Taxonomy $taxonomy): void
+    {
+        Validator::validate($metadata, $this->rules($taxonomy));
+    }
+
+    public function rules(Taxonomy $taxonomy): array
+    {
+        $rules = [];
+        foreach ($taxonomy->properties as $property) {
+            $rules[$property['code']] = $this->ruleForType($property['data_type']);
+        }
+        return $rules;
+    }
+
+    protected function ruleForType(string $type): string
+    {
+        switch ($type) {
+            case 'string':
+                return 'nullable|string';
+            case 'email':
+                return 'nullable|email';
+            case 'integer':
+                return 'nullable|integer';
+            case 'float':
+                return 'nullable|numeric';
+            case 'boolean':
+                return 'nullable|boolean';
+            case 'date':
+            case 'datetime':
+                return 'nullable|date';
+            case 'url':
+                return 'nullable|url';
+            case 'file':
+                return 'nullable|exists:taxonomy_files,id';
+            default:
+                return 'nullable';
+        }
+    }
+}

--- a/app/Http/Controllers/Backend/TaxonomyTermController.php
+++ b/app/Http/Controllers/Backend/TaxonomyTermController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Backend;
 
 use Illuminate\Http\Request;
+use App\Domains\Taxonomy\Validators\TaxonomyTermMetadataValidator;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
@@ -32,7 +33,7 @@ class TaxonomyTermController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param \Illuminate\Http\Request $request
+     * @param Request $request
      * @return \Illuminate\Http\RedirectResponse|void
      */
     public function store(Request $request, Taxonomy $taxonomy, TaxonomyTerm $taxonomyTerm)
@@ -46,7 +47,8 @@ class TaxonomyTermController extends Controller
                 'metadata' => 'array',
             ]);
 
-            $this->validateMetadata($request, $taxonomy);
+            app(TaxonomyTermMetadataValidator::class)
+                ->validate($request->input('metadata', []), $taxonomy);
 
             $metadataArray = [];
 
@@ -92,13 +94,12 @@ class TaxonomyTermController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param \App\Domains\TaxonomyTerm\Models\TaxonomyTerm $taxonomyTerm
+     * @param Request $request
+     * @param \App\Domains\Taxonomy\Models\TaxonomyTerm $taxonomyTerm
      * @return \Illuminate\Http\RedirectResponse
      */
     public function update(Request $request, Taxonomy $taxonomy, TaxonomyTerm $term)
     {
-        // try {
         $validatedData = $request->validate([
             'code' => 'required|unique:taxonomy_terms,code,' . $term->id,
             'name' => 'required',
@@ -106,7 +107,8 @@ class TaxonomyTermController extends Controller
             'metadata' => 'array',
         ]);
 
-        $this->validateMetadata($request, $taxonomy);
+        app(TaxonomyTermMetadataValidator::class)
+            ->validate($request->input('metadata', []), $taxonomy);
 
         $metadataArray = [];
         foreach ($taxonomy->properties as $property) {
@@ -145,55 +147,6 @@ class TaxonomyTermController extends Controller
         return view('backend.taxonomy.terms.delete', compact('taxonomy', 'term'));
     }
 
-
-    public function validateMetadata($request, Taxonomy $taxonomy)
-    {
-        foreach ($taxonomy->properties as $property) {
-            $metadataKey = "metadata.{$property['code']}";
-
-            // dd($request);
-            switch ($property['data_type']) {
-                case 'string':
-                    // dd($request, [$metadataKey => 'nullable|string']);
-                    // dd($request->validate([$metadataKey => 'nullable|string']));
-                    $request->validate([$metadataKey => 'nullable|string']);
-                    // throw new \InvalidArgumentException("Invalid data type for property '{$property['code']}'");
-                    break;
-                case 'email':
-                    $request->validate([$metadataKey => 'nullable|email']);
-                    // throw new \InvalidArgumentException("Invalid data type for property '{$property['code']}'");
-                    break;
-                case 'integer':
-                    $request->validate([$metadataKey => 'nullable|integer']);
-                    // throw new \InvalidArgumentException("Invalid data type for property '{$property['code']}'");
-                    break;
-                case 'float':
-                    $request->validate([$metadataKey => 'nullable|numeric']);
-                    // throw new \InvalidArgumentException("Invalid data type for property '{$property['code']}'");
-                    break;
-                case 'boolean':
-                    $request->validate([$metadataKey => 'nullable|boolean']);
-                    // throw new \InvalidArgumentException("Invalid data type for property '{$property['code']}'");
-                    break;
-                case 'date':
-                    $request->validate([$metadataKey => 'nullable|date']);
-                    // throw new \InvalidArgumentException("Invalid data type for property '{$property['code']}'");
-                    break;
-                case 'datetime':
-                    $request->validate([$metadataKey => 'nullable|date']);
-                    // throw new \InvalidArgumentException("Invalid data type for property '{$property['code']}'");
-                    break;
-                case 'url':
-                    $request->validate([$metadataKey => 'nullable|url']);
-                    // throw new \InvalidArgumentException("Invalid data type for property '{$property['code']}'");
-                    break;
-                case 'file':
-                    $request->validate([$metadataKey => 'nullable|exists:taxonomy_files,id']);
-                    // throw new \InvalidArgumentException("Invalid data type for property '{$property['code']}'");
-                    break;
-            }
-        }
-    }
 
     /**
      * Remove the specified resource from storage.


### PR DESCRIPTION
## Summary
- introduce `TaxonomyTermMetadataValidator` for dynamic term metadata rules
- remove previously added FormRequest classes
- validate metadata inside controller using new validator

## Testing
- `composer test` *(fails: imagecreatetruecolor missing and blocked HTTP requests)*

------
https://chatgpt.com/codex/tasks/task_e_684ecb8d63a48326b7dbf921c7531504