### PR TITLE
Implement taxonomy term history logging

### DIFF
--- a/app/Http/Controllers/Backend/TaxonomyController.php
+++ b/app/Http/Controllers/Backend/TaxonomyController.php
@@ -8,6 +8,8 @@ use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
 use App\Domains\Taxonomy\Models\Taxonomy;
 use App\Domains\Taxonomy\Models\TaxonomyTerm;
+use App\Domains\Taxonomy\Models\TaxonomyFile;
+use Spatie\Activitylog\Models\Activity;
 
 class TaxonomyController extends Controller
 {
@@ -148,6 +150,38 @@ class TaxonomyController extends Controller
             }
         }
         return true;
+    }
+
+    /**
+     * Display activity log for the given taxonomy.
+     */
+    public function history(Taxonomy $taxonomy)
+    {
+        $termIds = TaxonomyTerm::where('taxonomy_id', $taxonomy->id)->pluck('id');
+        $fileIds = TaxonomyFile::where('taxonomy_id', $taxonomy->id)->pluck('id');
+
+        $activities = Activity::where(function ($query) use ($taxonomy, $termIds, $fileIds) {
+            $query->where(function ($q) use ($taxonomy) {
+                $q->where('subject_type', Taxonomy::class)
+                    ->where('subject_id', $taxonomy->id);
+            })
+            ->orWhere(function ($q) use ($termIds) {
+                $q->where('subject_type', TaxonomyTerm::class)
+                    ->whereIn('subject_id', $termIds);
+            })
+            ->orWhere(function ($q) use ($fileIds) {
+                $q->where('subject_type', TaxonomyFile::class)
+                    ->whereIn('subject_id', $fileIds);
+            });
+        })
+        ->with(['causer', 'subject'])
+        ->orderByDesc('created_at')
+        ->get();
+
+        return view('backend.taxonomy.history', [
+            'taxonomy'   => $taxonomy,
+            'activities' => $activities,
+        ]);
     }
     /**
      * Confirm to delete the specified resource from storage.

--- a/app/Http/Controllers/Backend/TaxonomyTermController.php
+++ b/app/Http/Controllers/Backend/TaxonomyTermController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
 use App\Domains\Taxonomy\Models\Taxonomy;
 use App\Domains\Taxonomy\Models\TaxonomyTerm;
+use Spatie\Activitylog\Models\Activity;
 
 class TaxonomyTermController extends Controller
 {
@@ -158,5 +159,23 @@ class TaxonomyTermController extends Controller
             Log::error('Failed to delete taxonomy term', ['term_id' => $term->id, 'error' => $ex->getMessage()]);
             return back()->withErrors(['error' => 'Failed to delete taxonomy term. Please try again.']);
         }
+    }
+
+    /**
+     * Display activity log for the given taxonomy term.
+     */
+    public function history(Taxonomy $taxonomy, TaxonomyTerm $term)
+    {
+        $activities = Activity::where('subject_type', TaxonomyTerm::class)
+            ->where('subject_id', $term->id)
+            ->with(['causer', 'subject'])
+            ->orderByDesc('created_at')
+            ->get();
+
+        return view('backend.taxonomy.terms.history', [
+            'taxonomy'   => $taxonomy,
+            'term'       => $term,
+            'activities' => $activities,
+        ]);
     }
 }

--- a/resources/views/backend/taxonomy/history.blade.php
+++ b/resources/views/backend/taxonomy/history.blade.php
@@ -1,0 +1,58 @@
+@extends('backend.layouts.app')
+
+@section('title', __('Taxonomy History'))
+
+@section('content')
+    <div class="container mt-4">
+        <h3>{{ __('Change History for') }}: {{ $taxonomy->name }}</h3>
+
+        <x-backend.card>
+            <x-slot name="header">{{ __('History Log') }}</x-slot>
+            <x-slot name="body">
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>{{ __('Date') }}</th>
+                                <th>{{ __('User') }}</th>
+                                <th>{{ __('Item') }}</th>
+                                <th>{{ __('Description') }}</th>
+                                <th>{{ __('Changes') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($activities as $activity)
+                                <tr>
+                                    <td>{{ $activity->created_at }}</td>
+                                    <td>{{ $activity->causer->name ?? 'System' }}</td>
+                                    <td>
+                                        @php
+                                            $subject = $activity->subject;
+                                            $subjectName = $subject?->name ?? ($subject?->file_name ?? '#'.$activity->subject_id);
+                                        @endphp
+                                        {{ class_basename($activity->subject_type) }}: {{ $subjectName }}
+                                    </td>
+                                    <td>{{ $activity->description }}</td>
+                                    <td>
+                                        @if($activity->properties['attributes'] ?? false)
+                                            <ul class="mb-0 list-unstyled">
+                                                @foreach($activity->properties['attributes'] as $field => $new)
+                                                    @php $old = $activity->properties['old'][$field] ?? null; @endphp
+                                                    <li><strong>{{ $field }}</strong>: {{ $old }} &rarr; {{ $new }}</li>
+                                                @endforeach
+                                            </ul>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="5" class="text-center">{{ __('No activity recorded.') }}</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </x-slot>
+        </x-backend.card>
+    </div>
+@endsection

--- a/resources/views/backend/taxonomy/index-table-row.blade.php
+++ b/resources/views/backend/taxonomy/index-table-row.blade.php
@@ -49,6 +49,11 @@
                 <i class="fa fa-eye" title="View"></i>
             </a>
 
+            <!-- History Button -->
+            <a href="{{ route('dashboard.taxonomy.history', $row) }}" class="btn btn-sm btn-info">
+                <i class="fa fa-clock-o" title="History"></i>
+            </a>
+
             @if ($logged_in_user->hasPermissionTo('user.access.taxonomy.data.editor'))
                 <!-- Edit Button -->
                 <a href="{{ route('dashboard.taxonomy.edit', $row) }}" class="btn btn-sm btn-warning">

--- a/resources/views/backend/taxonomy/terms/history.blade.php
+++ b/resources/views/backend/taxonomy/terms/history.blade.php
@@ -1,0 +1,50 @@
+@extends('backend.layouts.app')
+
+@section('title', __('Taxonomy Term History'))
+
+@section('content')
+    <div class="container mt-4">
+        <h3>{{ __('Change History for') }}: {{ $term->name }}</h3>
+
+        <x-backend.card>
+            <x-slot name="header">{{ __('History Log') }}</x-slot>
+            <x-slot name="body">
+                <div class="table-responsive">
+                    <table class="table table-striped">
+                        <thead>
+                            <tr>
+                                <th>{{ __('Date') }}</th>
+                                <th>{{ __('User') }}</th>
+                                <th>{{ __('Description') }}</th>
+                                <th>{{ __('Changes') }}</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            @forelse ($activities as $activity)
+                                <tr>
+                                    <td>{{ $activity->created_at }}</td>
+                                    <td>{{ $activity->causer->name ?? 'System' }}</td>
+                                    <td>{{ $activity->description }}</td>
+                                    <td>
+                                        @if ($activity->properties['attributes'] ?? false)
+                                            <ul class="mb-0 list-unstyled">
+                                                @foreach($activity->properties['attributes'] as $field => $new)
+                                                    @php $old = $activity->properties['old'][$field] ?? null; @endphp
+                                                    <li><strong>{{ $field }}</strong>: {{ $old }} &rarr; {{ $new }}</li>
+                                                @endforeach
+                                            </ul>
+                                        @endif
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="4" class="text-center">{{ __('No activity recorded.') }}</td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </x-slot>
+        </x-backend.card>
+    </div>
+@endsection

--- a/resources/views/backend/taxonomy/terms/index-table-row.blade.php
+++ b/resources/views/backend/taxonomy/terms/index-table-row.blade.php
@@ -44,6 +44,11 @@
                 </a>
             @endif
 
+            <!-- History Button -->
+            <a href="{{ route('dashboard.taxonomy.terms.history', ['taxonomy' => $row->taxonomy_id, 'term' => $row->id]) }}" class="btn btn-sm btn-info">
+                <i class="fa fa-clock-o" title="History"></i>
+            </a>
+
             @if ($logged_in_user->hasPermissionTo('user.access.taxonomy.data.editor'))
                 <!-- Edit Button -->
                 <a href="{{ route('dashboard.taxonomy.terms.edit', ['taxonomy' => $row->taxonomy_id, 'term' => $row->id]) }}"

--- a/routes/backend/taxonomy.php
+++ b/routes/backend/taxonomy.php
@@ -28,6 +28,16 @@ Route::group(['middleware' => ['permission:user.access.taxonomy.data.editor|user
                 ->push(__('View'));
         });
 
+    // History
+    Route::get('taxonomy/history/{taxonomy}', [TaxonomyController::class, 'history'])
+        ->name('taxonomy.history')
+        ->breadcrumbs(function (Trail $trail, $taxonomy) {
+            $trail->push(__('Home'), route('dashboard.home'))
+                ->push(__('Taxonomy'), route('dashboard.taxonomy.index'))
+                ->push($taxonomy->name)
+                ->push(__('History'));
+        });
+
     // Only Editors have access to these functionalities
     Route::group(['middleware' => ['permission:user.access.taxonomy.data.editor']], function () {
 
@@ -82,6 +92,17 @@ Route::group(['middleware' => ['permission:user.access.taxonomy.data.editor|user
                     ->push(__('Taxonomy'), route('dashboard.taxonomy.index'))
                     ->push($taxonomy->name)
                     ->push(__('Terms'), route('dashboard.taxonomy.terms.index', $taxonomy));
+            });
+
+        // History
+        Route::get('/history/{term}', [TaxonomyTermController::class, 'history'])
+            ->name('taxonomy.terms.history')
+            ->breadcrumbs(function (Trail $trail, $taxonomy, $term) {
+                $trail->push(__('Home'), route('dashboard.home'))
+                    ->push(__('Taxonomy'), route('dashboard.taxonomy.index'))
+                    ->push($taxonomy->name, route('dashboard.taxonomy.terms.index', $taxonomy))
+                    ->push($term->name)
+                    ->push(__('History'));
             });
 
         // Only Editors have access to these functionalities


### PR DESCRIPTION
## Summary
- add history route for taxonomy terms
- implement controller logic to gather term activity logs
- create history blade view for taxonomy terms
- link to history from taxonomy term table

## Testing
- `composer test` *(fails: Call to undefined function Illuminate\Http\Testing\imagecreatetruecolor())*

------
https://chatgpt.com/codex/tasks/task_e_6857eee3ca5c8326b4d3eac21e49185b