### PR TITLE
Add Taxonomy Pages with rich text editing

### DIFF
--- a/app/Domains/Taxonomy/Models/Taxonomy.php
+++ b/app/Domains/Taxonomy/Models/Taxonomy.php
@@ -7,6 +7,7 @@ use Database\Factories\TaxonomyFactory;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\Activitylog\Traits\LogsActivity;
 use App\Domains\Taxonomy\Models\TaxonomyTerm;
+use App\Domains\Taxonomy\Models\TaxonomyPage;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use App\Domains\Taxonomy\Models\Traits\Scope\TaxonomyScope;
 
@@ -95,6 +96,14 @@ class Taxonomy extends Model
         return $this->hasMany(TaxonomyFile::class, 'taxonomy_id')
             ->orderBy('file_name', 'asc')
             ->pluck('file_name', 'id');
+    }
+
+    /**
+     * Get the pages associated with the taxonomy.
+     */
+    public function pages()
+    {
+        return $this->hasMany(TaxonomyPage::class, 'taxonomy_id');
     }
 
     public function first_child_terms()

--- a/app/Domains/Taxonomy/Models/TaxonomyPage.php
+++ b/app/Domains/Taxonomy/Models/TaxonomyPage.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Domains\Taxonomy\Models;
+
+use App\Domains\Auth\Models\User;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Storage;
+use Spatie\Activitylog\Traits\LogsActivity;
+use Database\Factories\TaxonomyPageFactory;
+
+/**
+ * Class TaxonomyPage
+ */
+class TaxonomyPage extends Model
+{
+    use HasFactory, LogsActivity;
+
+    /** @var string[] */
+    protected $fillable = [
+        'taxonomy_id',
+        'slug',
+        'html',
+    ];
+
+    /** @var array<string,string> */
+    protected $casts = [
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+    ];
+
+    /**
+     * Boot the model.
+     */
+    protected static function booted(): void
+    {
+        static::saved(function (self $page): void {
+            Storage::disk('public')->put("taxonomy-pages/{$page->slug}.html", $page->html);
+        });
+
+        static::deleted(function (self $page): void {
+            Storage::disk('public')->delete("taxonomy-pages/{$page->slug}.html");
+        });
+    }
+
+    /** @return \Illuminate\Database\Eloquent\Relations\BelongsTo */
+    public function taxonomy()
+    {
+        return $this->belongsTo(Taxonomy::class);
+    }
+
+    /** @return \Illuminate\Database\Eloquent\Relations\BelongsTo */
+    public function user_created()
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    /** @return \Illuminate\Database\Eloquent\Relations\BelongsTo */
+    public function user_updated()
+    {
+        return $this->belongsTo(User::class, 'updated_by');
+    }
+
+    /**
+     * Create a new factory instance for the model.
+     */
+    protected static function newFactory()
+    {
+        return TaxonomyPageFactory::new();
+    }
+}

--- a/app/Http/Controllers/Backend/UploadController.php
+++ b/app/Http/Controllers/Backend/UploadController.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Controllers\Backend;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Storage;
+
+class UploadController extends Controller
+{
+    /**
+     * Handle image upload from the rich text editor.
+     */
+    public function store(Request $request)
+    {
+        $request->validate([
+            'upload' => 'required|image|max:10240',
+        ]);
+
+        $path = $request->file('upload')->store('uploads', 'public');
+
+        return response()->json(['url' => Storage::disk('public')->url($path)]);
+    }
+}

--- a/app/Http/Livewire/Backend/TaxonomyPagesForm.php
+++ b/app/Http/Livewire/Backend/TaxonomyPagesForm.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Livewire\Backend;
+
+use Livewire\Component;
+use App\Domains\Taxonomy\Models\TaxonomyPage;
+use App\Domains\Taxonomy\Models\Taxonomy;
+use Illuminate\Support\Facades\Auth;
+
+class TaxonomyPagesForm extends Component
+{
+    public ?TaxonomyPage $page = null;
+    public $slug = '';
+    public $html = '';
+    public $taxonomy_id = null;
+
+    /** @return array */
+    protected function rules()
+    {
+        $id = $this->page->id ?? null;
+        return [
+            'slug' => ['required', 'string', 'max:255', 'unique:taxonomy_pages,slug,' . $id],
+            'html' => ['required', 'string'],
+            'taxonomy_id' => ['nullable', 'exists:taxonomies,id'],
+        ];
+    }
+
+    public function mount(?TaxonomyPage $taxonomyPage = null): void
+    {
+        if ($taxonomyPage) {
+            $this->page = $taxonomyPage;
+            $this->slug = $taxonomyPage->slug;
+            $this->html = $taxonomyPage->html;
+            $this->taxonomy_id = $taxonomyPage->taxonomy_id;
+        }
+    }
+
+    public function save(): void
+    {
+        $this->validate();
+
+        $data = [
+            'slug' => $this->slug,
+            'html' => $this->html,
+            'taxonomy_id' => $this->taxonomy_id,
+        ];
+
+        if ($this->page) {
+            $data['updated_by'] = Auth::id();
+            $this->page->update($data);
+        } else {
+            $data['created_by'] = Auth::id();
+            $this->page = TaxonomyPage::create($data);
+        }
+
+        session()->flash('Success', 'Taxonomy Page saved successfully');
+        redirect()->route('dashboard.taxonomy-pages.index');
+    }
+
+    public function render()
+    {
+        $taxonomies = Taxonomy::select('id', 'name')->orderBy('name')->get();
+        return view('livewire.backend.taxonomy-pages-form', [
+            'taxonomies' => $taxonomies,
+        ]);
+    }
+}

--- a/app/Http/Livewire/Backend/TaxonomyPagesTable.php
+++ b/app/Http/Livewire/Backend/TaxonomyPagesTable.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Livewire\Backend;
+
+use App\Domains\Taxonomy\Models\TaxonomyPage;
+use App\Domains\Taxonomy\Models\Taxonomy;
+use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+use Rappasoft\LaravelLivewireTables\Views\Filter;
+
+class TaxonomyPagesTable extends DataTableComponent
+{
+    public array $perPageAccepted = [10, 25, 50, 100];
+    public int $perPage = 25;
+    public bool $perPageAll = true;
+    public string $defaultSortColumn = 'created_at';
+    public string $defaultSortDirection = 'desc';
+
+    public function columns(): array
+    {
+        return [
+            Column::make('Slug', 'slug')->searchable()->sortable(),
+            Column::make('Taxonomy', 'taxonomy.name'),
+            Column::make('Created by', 'created_by')->sortable(),
+            Column::make('Updated by', 'updated_by')->sortable(),
+            Column::make('Created at', 'created_at')->sortable(),
+            Column::make('Updated at', 'updated_at')->sortable(),
+            Column::make('Actions'),
+        ];
+    }
+
+    public function query(): Builder
+    {
+        return TaxonomyPage::query()
+            ->with('taxonomy')
+            ->when($this->getFilter('taxonomy_id'), fn ($q, $id) => $q->where('taxonomy_id', $id));
+    }
+
+    public function filters(): array
+    {
+        $taxonomy = [];
+        foreach (Taxonomy::query()->get() as $value) {
+            $taxonomy[$value->id] = $value->name;
+        }
+
+        return [
+            'taxonomy_id' => Filter::make('Taxonomy')->select($taxonomy)
+        ];
+    }
+
+    public function rowView(): string
+    {
+        return 'backend.taxonomy_pages.index-table-row';
+    }
+}

--- a/app/Http/Resources/TaxonomyPageResource.php
+++ b/app/Http/Resources/TaxonomyPageResource.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Domains\Auth\Models\User;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+class TaxonomyPageResource extends JsonResource
+{
+    /**
+     * Transform the resource into an array.
+     */
+    public function toArray($request): array
+    {
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'html' => $this->html,
+            'taxonomy_id' => $this->taxonomy_id,
+            'created_by' => User::find($this->created_by)?->name,
+            'updated_by' => User::find($this->updated_by)?->name,
+            'created_at' => $this->created_at,
+            'updated_at' => $this->updated_at,
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "laravel/sail": "^1.0.1",
         "mockery/mockery": "^1.4.2",
         "nunomaduro/collision": "^5.0",
+        "pestphp/pest": "^1.23",
         "phpunit/phpunit": "^9.6"
     },
     "autoload": {
@@ -103,7 +104,8 @@
         "preferred-install": "dist",
         "sort-packages": true,
         "allow-plugins": {
-            "php-http/discovery": true
+            "php-http/discovery": true,
+            "pestphp/pest-plugin": true
         }
     },
     "minimum-stability": "dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "238d94403ecc4351509122d944155560",
+    "content-hash": "aa8342adcd11632b62ddde59940dd6d9",
     "packages": [
         {
             "name": "arcanedev/log-viewer",
@@ -200,16 +200,16 @@
         },
         {
             "name": "brick/math",
-            "version": "0.12.3",
+            "version": "0.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/brick/math.git",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba"
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/brick/math/zipball/866551da34e9a618e64a819ee1e01c20d8a588ba",
-                "reference": "866551da34e9a618e64a819ee1e01c20d8a588ba",
+                "url": "https://api.github.com/repos/brick/math/zipball/fc7ed316430118cc7836bf45faff18d5dfc8de04",
+                "reference": "fc7ed316430118cc7836bf45faff18d5dfc8de04",
                 "shasum": ""
             },
             "require": {
@@ -248,7 +248,7 @@
             ],
             "support": {
                 "issues": "https://github.com/brick/math/issues",
-                "source": "https://github.com/brick/math/tree/0.12.3"
+                "source": "https://github.com/brick/math/tree/0.13.1"
             },
             "funding": [
                 {
@@ -256,7 +256,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-28T13:11:00+00:00"
+            "time": "2025-03-29T13:50:30+00:00"
         },
         {
             "name": "carbonphp/carbon-doctrine-types",
@@ -903,16 +903,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.9.4",
+            "version": "3.9.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "ec16c82f20be1a7224e65ac67144a29199f87959"
+                "reference": "4a4e2eed3134036ee36a147ee0dac037dfa17868"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/ec16c82f20be1a7224e65ac67144a29199f87959",
-                "reference": "ec16c82f20be1a7224e65ac67144a29199f87959",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/4a4e2eed3134036ee36a147ee0dac037dfa17868",
+                "reference": "4a4e2eed3134036ee36a147ee0dac037dfa17868",
                 "shasum": ""
             },
             "require": {
@@ -925,14 +925,14 @@
                 "psr/log": "^1|^2|^3"
             },
             "require-dev": {
-                "doctrine/coding-standard": "12.0.0",
+                "doctrine/coding-standard": "13.0.0",
                 "fig/log-test": "^1",
                 "jetbrains/phpstorm-stubs": "2023.1",
-                "phpstan/phpstan": "2.1.1",
+                "phpstan/phpstan": "2.1.17",
                 "phpstan/phpstan-strict-rules": "^2",
-                "phpunit/phpunit": "9.6.22",
-                "slevomat/coding-standard": "8.13.1",
-                "squizlabs/php_codesniffer": "3.10.2",
+                "phpunit/phpunit": "9.6.23",
+                "slevomat/coding-standard": "8.16.2",
+                "squizlabs/php_codesniffer": "3.13.1",
                 "symfony/cache": "^5.4|^6.0|^7.0",
                 "symfony/console": "^4.4|^5.4|^6.0|^7.0"
             },
@@ -994,7 +994,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.9.4"
+                "source": "https://github.com/doctrine/dbal/tree/3.9.5"
             },
             "funding": [
                 {
@@ -1010,7 +1010,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-16T08:28:55+00:00"
+            "time": "2025-06-15T22:40:05+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -2616,16 +2616,16 @@
         },
         {
             "name": "laravel/socialite",
-            "version": "v5.20.0",
+            "version": "v5.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/socialite.git",
-                "reference": "30972c12a41f71abeb418bc9ff157da8d9231519"
+                "reference": "d83639499ad14985c9a6a9713b70073300ce998d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/socialite/zipball/30972c12a41f71abeb418bc9ff157da8d9231519",
-                "reference": "30972c12a41f71abeb418bc9ff157da8d9231519",
+                "url": "https://api.github.com/repos/laravel/socialite/zipball/d83639499ad14985c9a6a9713b70073300ce998d",
+                "reference": "d83639499ad14985c9a6a9713b70073300ce998d",
                 "shasum": ""
             },
             "require": {
@@ -2684,7 +2684,7 @@
                 "issues": "https://github.com/laravel/socialite/issues",
                 "source": "https://github.com/laravel/socialite"
             },
-            "time": "2025-04-21T14:21:34+00:00"
+            "time": "2025-05-19T12:56:37+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -3379,12 +3379,12 @@
             "version": "v1.4.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/marvinlabs/laravel-discord-logger.git",
+                "url": "https://github.com/vpratfr/laravel-discord-logger.git",
                 "reference": "b484e9742bc174920712434222f16654c343cf9b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/marvinlabs/laravel-discord-logger/zipball/b484e9742bc174920712434222f16654c343cf9b",
+                "url": "https://api.github.com/repos/vpratfr/laravel-discord-logger/zipball/b484e9742bc174920712434222f16654c343cf9b",
                 "reference": "b484e9742bc174920712434222f16654c343cf9b",
                 "shasum": ""
             },
@@ -3433,8 +3433,8 @@
                 "logging"
             ],
             "support": {
-                "issues": "https://github.com/marvinlabs/laravel-discord-logger/issues",
-                "source": "https://github.com/marvinlabs/laravel-discord-logger/tree/v1.4.3"
+                "issues": "https://github.com/vpratfr/laravel-discord-logger/issues",
+                "source": "https://github.com/vpratfr/laravel-discord-logger/tree/v1.4.3"
             },
             "funding": [
                 {
@@ -3717,16 +3717,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.0.6",
+            "version": "v4.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "ce708655043c7050eb050df361c5e313cf708309"
+                "reference": "e67c4061eb40b9c113b218214e42cb5a0dda28f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/ce708655043c7050eb050df361c5e313cf708309",
-                "reference": "ce708655043c7050eb050df361c5e313cf708309",
+                "url": "https://api.github.com/repos/nette/utils/zipball/e67c4061eb40b9c113b218214e42cb5a0dda28f2",
+                "reference": "e67c4061eb40b9c113b218214e42cb5a0dda28f2",
                 "shasum": ""
             },
             "require": {
@@ -3797,22 +3797,22 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.0.6"
+                "source": "https://github.com/nette/utils/tree/v4.0.7"
             },
-            "time": "2025-03-30T21:06:30+00:00"
+            "time": "2025-06-03T04:55:08+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
                 "shasum": ""
             },
             "require": {
@@ -3855,9 +3855,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-05-31T08:24:38+00:00"
         },
         {
             "name": "nyholm/psr7",
@@ -4432,16 +4432,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.43",
+            "version": "3.0.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "709ec107af3cb2f385b9617be72af8cf62441d02"
+                "reference": "bd81b90d5963c6b9d87de50357585375223f4dd8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/709ec107af3cb2f385b9617be72af8cf62441d02",
-                "reference": "709ec107af3cb2f385b9617be72af8cf62441d02",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/bd81b90d5963c6b9d87de50357585375223f4dd8",
+                "reference": "bd81b90d5963c6b9d87de50357585375223f4dd8",
                 "shasum": ""
             },
             "require": {
@@ -4522,7 +4522,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.43"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.45"
             },
             "funding": [
                 {
@@ -4538,7 +4538,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-14T21:12:59+00:00"
+            "time": "2025-06-22T22:54:43+00:00"
         },
         {
             "name": "psr/cache",
@@ -4998,16 +4998,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.8",
+            "version": "v0.12.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "85057ceedee50c49d4f6ecaff73ee96adb3b3625"
+                "reference": "1b801844becfe648985372cb4b12ad6840245ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/85057ceedee50c49d4f6ecaff73ee96adb3b3625",
-                "reference": "85057ceedee50c49d4f6ecaff73ee96adb3b3625",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/1b801844becfe648985372cb4b12ad6840245ace",
+                "reference": "1b801844becfe648985372cb4b12ad6840245ace",
                 "shasum": ""
             },
             "require": {
@@ -5071,9 +5071,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.8"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.9"
             },
-            "time": "2025-03-16T03:05:19+00:00"
+            "time": "2025-06-23T02:35:06+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -5197,20 +5197,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.6",
+            "version": "4.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "91039bc1faa45ba123c4328958e620d382ec7088"
+                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/91039bc1faa45ba123c4328958e620d382ec7088",
-                "reference": "91039bc1faa45ba123c4328958e620d382ec7088",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
+                "reference": "fdf4dd4e2ff1813111bd0ad58d7a1ddbb5b56c28",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13",
                 "ext-json": "*",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
@@ -5219,26 +5219,23 @@
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "captainhook/captainhook": "^5.10",
+                "captainhook/captainhook": "^5.25",
                 "captainhook/plugin-composer": "^5.3",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "doctrine/annotations": "^1.8",
-                "ergebnis/composer-normalize": "^2.15",
-                "mockery/mockery": "^1.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "ergebnis/composer-normalize": "^2.47",
+                "mockery/mockery": "^1.6",
                 "paragonie/random-lib": "^2",
-                "php-mock/php-mock": "^2.2",
-                "php-mock/php-mock-mockery": "^1.3",
-                "php-parallel-lint/php-parallel-lint": "^1.1",
-                "phpbench/phpbench": "^1.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^8.5 || ^9",
-                "ramsey/composer-repl": "^1.4",
-                "slevomat/coding-standard": "^8.4",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.9"
+                "php-mock/php-mock": "^2.6",
+                "php-mock/php-mock-mockery": "^1.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpbench/phpbench": "^1.2.14",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "slevomat/coding-standard": "^8.18",
+                "squizlabs/php_codesniffer": "^3.13"
             },
             "suggest": {
                 "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
@@ -5273,19 +5270,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.6"
+                "source": "https://github.com/ramsey/uuid/tree/4.8.1"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/ramsey",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/ramsey/uuid",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-04-27T21:32:50+00:00"
+            "time": "2025-06-01T06:28:46+00:00"
         },
         {
             "name": "rappasoft/laravel-livewire-tables",
@@ -5833,7 +5820,7 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -5878,7 +5865,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.2.0"
+                "source": "https://github.com/symfony/css-selector/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -5898,16 +5885,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -5920,7 +5907,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -5945,7 +5932,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -5961,7 +5948,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -6116,16 +6103,16 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
-                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
                 "shasum": ""
             },
             "require": {
@@ -6139,7 +6126,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -6172,7 +6159,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -6188,7 +6175,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/finder",
@@ -7319,16 +7306,16 @@
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
                 "shasum": ""
             },
             "require": {
@@ -7346,7 +7333,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -7382,7 +7369,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -7398,7 +7385,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2025-04-25T09:37:31+00:00"
         },
         {
             "name": "symfony/string",
@@ -7488,16 +7475,16 @@
         },
         {
             "name": "symfony/translation",
-            "version": "v6.4.21",
+            "version": "v6.4.22",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "bb92ea5588396b319ba43283a5a3087a034cb29c"
+                "reference": "7e3b3b7146c6fab36ddff304a8041174bf6e17ad"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/bb92ea5588396b319ba43283a5a3087a034cb29c",
-                "reference": "bb92ea5588396b319ba43283a5a3087a034cb29c",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/7e3b3b7146c6fab36ddff304a8041174bf6e17ad",
+                "reference": "7e3b3b7146c6fab36ddff304a8041174bf6e17ad",
                 "shasum": ""
             },
             "require": {
@@ -7563,7 +7550,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v6.4.21"
+                "source": "https://github.com/symfony/translation/tree/v6.4.22"
             },
             "funding": [
                 {
@@ -7579,20 +7566,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-07T19:02:30+00:00"
+            "time": "2025-05-29T07:06:44+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c"
+                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/4667ff3bd513750603a09c8dedbea942487fb07c",
-                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
+                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
                 "shasum": ""
             },
             "require": {
@@ -7605,7 +7592,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -7641,7 +7628,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -7657,7 +7644,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-27T08:32:26+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -9301,16 +9288,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.18.0",
+            "version": "2.18.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e"
+                "reference": "59a123a3d459c5a23055802237cb317f609867e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e",
-                "reference": "a7de6c3c6c3c022f5cfc337f8ede6a14460cf77e",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/59a123a3d459c5a23055802237cb317f609867e5",
+                "reference": "59a123a3d459c5a23055802237cb317f609867e5",
                 "shasum": ""
             },
             "require": {
@@ -9360,7 +9347,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.18.0"
+                "source": "https://github.com/filp/whoops/tree/2.18.3"
             },
             "funding": [
                 {
@@ -9368,7 +9355,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-15T12:00:00+00:00"
+            "time": "2025-06-16T00:02:10+00:00"
         },
         {
             "name": "friendsofphp/php-cs-fixer",
@@ -9948,6 +9935,171 @@
                 }
             ],
             "time": "2022-01-10T16:22:52+00:00"
+        },
+        {
+            "name": "pestphp/pest",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest.git",
+                "reference": "5c56ad8772b89611c72a07e23f6e30aa29dc677a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/5c56ad8772b89611c72a07e23f6e30aa29dc677a",
+                "reference": "5c56ad8772b89611c72a07e23f6e30aa29dc677a",
+                "shasum": ""
+            },
+            "require": {
+                "nunomaduro/collision": "^5.11.0|^6.4.0",
+                "pestphp/pest-plugin": "^1.1.0",
+                "php": "^7.3 || ^8.0",
+                "phpunit/phpunit": "^9.6.10"
+            },
+            "require-dev": {
+                "illuminate/console": "^8.83.27",
+                "illuminate/support": "^8.83.27",
+                "laravel/dusk": "^6.25.2",
+                "pestphp/pest-dev-tools": "^1.0.0",
+                "pestphp/pest-plugin-parallel": "^1.2.1"
+            },
+            "bin": [
+                "bin/pest"
+            ],
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Plugins\\Coverage",
+                        "Pest\\Plugins\\Init",
+                        "Pest\\Plugins\\Version",
+                        "Pest\\Plugins\\Environment"
+                    ]
+                },
+                "laravel": {
+                    "providers": [
+                        "Pest\\Laravel\\PestServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php",
+                    "src/Pest.php"
+                ],
+                "psr-4": {
+                    "Pest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "An elegant PHP Testing Framework.",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/pestphp/pest/issues",
+                "source": "https://github.com/pestphp/pest/tree/v1.23.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-07-12T19:42:47+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin.git",
+                "reference": "606c5f79c6a339b49838ffbee0151ca519efe378"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/606c5f79c6a339b49838ffbee0151ca519efe378",
+                "reference": "606c5f79c6a339b49838ffbee0151ca519efe378",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1.0 || ^2.0.0",
+                "php": "^7.3 || ^8.0"
+            },
+            "conflict": {
+                "pestphp/pest": "<1.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.4.2",
+                "pestphp/pest": "^1.22.1",
+                "pestphp/pest-dev-tools": "^1.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Pest\\Plugin\\Manager",
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest plugin manager",
+            "keywords": [
+                "framework",
+                "manager",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin/tree/v1.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2022-09-18T13:18:17+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -12146,7 +12298,7 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -12192,7 +12344,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -12212,16 +12364,16 @@
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "7da8fbac9dcfef75ffc212235d76b2754ce0cf50"
+                "reference": "afb9a8038025e5dbc657378bfab9198d75f10fca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/7da8fbac9dcfef75ffc212235d76b2754ce0cf50",
-                "reference": "7da8fbac9dcfef75ffc212235d76b2754ce0cf50",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/afb9a8038025e5dbc657378bfab9198d75f10fca",
+                "reference": "afb9a8038025e5dbc657378bfab9198d75f10fca",
                 "shasum": ""
             },
             "require": {
@@ -12259,7 +12411,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.2.0"
+                "source": "https://github.com/symfony/options-resolver/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -12275,7 +12427,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-20T11:17:29+00:00"
+            "time": "2025-04-04T13:12:05+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
@@ -12355,7 +12507,7 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v7.2.4",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
@@ -12397,7 +12549,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v7.2.4"
+                "source": "https://github.com/symfony/stopwatch/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -12547,5 +12699,5 @@
         "php": "^7.4|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/database/factories/TaxonomyPageFactory.php
+++ b/database/factories/TaxonomyPageFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Domains\Taxonomy\Models\TaxonomyPage;
+use App\Domains\Taxonomy\Models\Taxonomy;
+use App\Domains\Auth\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TaxonomyPageFactory extends Factory
+{
+    protected $model = TaxonomyPage::class;
+
+    public function definition(): array
+    {
+        return [
+            'slug' => $this->faker->unique()->slug,
+            'html' => '<p>'.$this->faker->sentence().'</p>',
+            'taxonomy_id' => $this->faker->boolean ? Taxonomy::factory() : null,
+            'created_by' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2025_06_23_171806_create_taxonomy_pages_table.php
+++ b/database/migrations/2025_06_23_171806_create_taxonomy_pages_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('taxonomy_pages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('taxonomy_id')->nullable()->constrained()->cascadeOnDelete();
+            $table->string('slug')->unique();
+            $table->longText('html');
+            $table->foreignId('created_by')->nullable()->constrained('users')->onUpdate('cascade')->onDelete('set null');
+            $table->foreignId('updated_by')->nullable()->constrained('users')->onUpdate('cascade')->onDelete('set null');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('taxonomy_pages');
+    }
+};

--- a/resources/views/backend/taxonomy_pages/create.blade.php
+++ b/resources/views/backend/taxonomy_pages/create.blade.php
@@ -1,0 +1,7 @@
+@extends('backend.layouts.app')
+
+@section('title', __('Create Taxonomy Page'))
+
+@section('content')
+    @livewire('backend.taxonomy-pages-form')
+@endsection

--- a/resources/views/backend/taxonomy_pages/edit.blade.php
+++ b/resources/views/backend/taxonomy_pages/edit.blade.php
@@ -1,0 +1,7 @@
+@extends('backend.layouts.app')
+
+@section('title', __('Edit Taxonomy Page'))
+
+@section('content')
+    @livewire('backend.taxonomy-pages-form', ['taxonomyPage' => $taxonomyPage])
+@endsection

--- a/resources/views/backend/taxonomy_pages/index-table-row.blade.php
+++ b/resources/views/backend/taxonomy_pages/index-table-row.blade.php
@@ -1,0 +1,34 @@
+<x-livewire-tables::table.cell>
+    {{ $row->slug }}
+</x-livewire-tables::table.cell>
+<x-livewire-tables::table.cell>
+    @if($row->taxonomy)
+        <a href="{{ route('dashboard.taxonomy.terms.index', $row->taxonomy) }}">{{ $row->taxonomy->name }}</a>
+    @else
+        —
+    @endif
+</x-livewire-tables::table.cell>
+<x-livewire-tables::table.cell>
+    {{ $row->user_created->name ?? 'N/A' }}
+</x-livewire-tables::table.cell>
+<x-livewire-tables::table.cell>
+    {{ $row->user_updated->name ?? 'N/A' }}
+</x-livewire-tables::table.cell>
+<x-livewire-tables::table.cell>
+    {{ $row->created_at }}
+</x-livewire-tables::table.cell>
+<x-livewire-tables::table.cell>
+    {{ $row->updated_at }}
+</x-livewire-tables::table.cell>
+<x-livewire-tables::table.cell>
+    <div class="btn-group" role="group">
+        <a href="{{ url('/taxonomy/' . $row->slug) }}" class="btn btn-sm btn-primary" target="_blank">
+            <i class="fa fa-eye"></i>
+        </a>
+        @if($logged_in_user->hasPermissionTo('user.taxonomy.data.editor'))
+            <a href="{{ route('dashboard.taxonomy-pages.edit', $row) }}" class="btn btn-sm btn-warning">
+                <i class="fa fa-pencil"></i>
+            </a>
+        @endif
+    </div>
+</x-livewire-tables::table.cell>

--- a/resources/views/backend/taxonomy_pages/index.blade.php
+++ b/resources/views/backend/taxonomy_pages/index.blade.php
@@ -9,6 +9,12 @@
                 {{ __('Taxonomy Pages') }}
             </x-slot>
 
+            <x-slot name="headerActions">
+                @if ($logged_in_user->hasPermissionTo('user.taxonomy.data.editor'))
+                    <x-utils.link icon="c-icon cil-plus" class="card-header-action" :href="route('dashboard.taxonomy-pages.create')" :text="__('Create Page')" />
+                @endif
+            </x-slot>
+
             <x-slot name="body">
                 @if (session('Success'))
                     <div class="alert alert-success alert-dismissible fade show" role="alert">
@@ -19,7 +25,7 @@
                     </div>
                 @endif
 
-                <p>This page is under development</p>
+                <livewire:backend.taxonomy-pages-table />
 
             </x-slot>
 

--- a/resources/views/livewire/backend/richtext-editor-component.blade.php
+++ b/resources/views/livewire/backend/richtext-editor-component.blade.php
@@ -7,10 +7,13 @@
             .create(document.querySelector('#{{ $name }}'), {
                 toolbar: [
                     'heading', '|',
-                    'bold', 'italic', 'link', '|',
+                    'bold', 'italic', 'link', 'imageUpload', '|',
                     'bulletedList', 'numberedList', 'blockQuote', '|',
-                    'undo', 'redo'
-                ]
+                    'undo', 'redo', 'fullscreen'
+                ],
+                ckfinder: {
+                    uploadUrl: '{{ route('dashboard.taxonomy-pages.upload-image') }}?&_token={{ csrf_token() }}'
+                }
             })
             .catch(error => {
                 console.error(error);

--- a/resources/views/livewire/backend/taxonomy-pages-form.blade.php
+++ b/resources/views/livewire/backend/taxonomy-pages-form.blade.php
@@ -1,0 +1,25 @@
+<div>
+    <form wire:submit.prevent="save">
+        <div class="mb-3">
+            <label for="slug" class="form-label">Slug</label>
+            <input type="text" id="slug" class="form-control" wire:model.defer="slug">
+            @error('slug') <span class="text-danger">{{ $message }}</span> @enderror
+        </div>
+        <div class="mb-3">
+            <label for="taxonomy" class="form-label">Taxonomy</label>
+            <select wire:model="taxonomy_id" id="taxonomy" class="form-control">
+                <option value="">— none —</option>
+                @foreach($taxonomies as $taxonomy)
+                    <option value="{{ $taxonomy->id }}">{{ $taxonomy->name }}</option>
+                @endforeach
+            </select>
+            @error('taxonomy_id') <span class="text-danger">{{ $message }}</span> @enderror
+        </div>
+        <div class="mb-3">
+            <label class="form-label">Content</label>
+            <livewire:backend.richtext-editor-component :name="page-html" :value="html" />
+            @error('html') <span class="text-danger">{{ $message }}</span> @enderror
+        </div>
+        <button type="submit" class="btn btn-primary">Save</button>
+    </form>
+</div>

--- a/routes/backend/taxonomy.php
+++ b/routes/backend/taxonomy.php
@@ -213,4 +213,34 @@ Route::group(['middleware' => ['permission:user.access.taxonomy.page.editor|user
             $trail->push(__('Home'), route('dashboard.home'))
                 ->push(__('Taxonomy Pages'), route('dashboard.taxonomy-pages.index'));
         });
+
+    // Image upload endpoint
+    Route::post('taxonomy-pages/upload-image', [\App\Http\Controllers\Backend\UploadController::class, 'store'])
+        ->name('taxonomy-pages.upload-image');
+
+    Route::group(['middleware' => ['permission:user.taxonomy.data.editor']], function () {
+        // Create
+        Route::get('taxonomy-pages/create', function () {
+            return view('backend.taxonomy_pages.create');
+        })
+            ->name('taxonomy-pages.create')
+            ->breadcrumbs(function (Trail $trail) {
+                $trail->push(__('Home'), route('dashboard.home'))
+                    ->push(__('Taxonomy Pages'), route('dashboard.taxonomy-pages.index'))
+                    ->push(__('Create'));
+            });
+
+        // Edit
+        Route::get('taxonomy-pages/edit/{taxonomyPage}', function ($taxonomyPage) {
+            return view('backend.taxonomy_pages.edit', ['taxonomyPage' => $taxonomyPage]);
+        })
+            ->name('taxonomy-pages.edit')
+            ->breadcrumbs(function (Trail $trail, $taxonomyPage) {
+                $trail->push(__('Home'), route('dashboard.home'))
+                    ->push(__('Taxonomy Pages'), route('dashboard.taxonomy-pages.index'))
+                    ->push($taxonomyPage->slug)
+                    ->push(__('Edit'));
+            });
+
+    });
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Backend\TaxonomyFileController;
 use App\Http\Controllers\LocaleController;
 use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Storage;
 
 /*
  * Global Routes
@@ -44,3 +45,11 @@ Route::group(
             ->withoutMiddleware(['permission:user.access.taxonomy.file.editor|user.access.taxonomy.file.viewer']);
     }
 );
+
+Route::get('taxonomy/{slug}', function ($slug) {
+    $path = "taxonomy-pages/{$slug}.html";
+    if (Storage::disk('public')->exists($path)) {
+        return Storage::disk('public')->get($path);
+    }
+    abort(404);
+})->name('taxonomy.page');

--- a/tests/Feature/Backend/TaxonomyPage/TaxonomyPageTest.php
+++ b/tests/Feature/Backend/TaxonomyPage/TaxonomyPageTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\Domains\Taxonomy\Models\TaxonomyPage;
+use App\Domains\Taxonomy\Models\Taxonomy;
+use App\Http\Resources\TaxonomyPageResource;
+use Illuminate\Support\Facades\Storage;
+use function Pest\Laravel\assertDatabaseHas;
+use function Pest\Laravel\assertDatabaseMissing;
+use Tests\TestCase;
+
+uses(TestCase::class)->in('Feature');
+
+beforeEach(function () {
+    Storage::fake('public');
+});
+
+test('taxonomy page creation writes html file', function () {
+    $taxonomy = Taxonomy::factory()->create();
+    $page = TaxonomyPage::factory()->create([
+        'taxonomy_id' => $taxonomy->id,
+        'slug' => 'sample-page',
+        'html' => '<p>hello</p>',
+    ]);
+
+    Storage::disk('public')->assertExists('taxonomy-pages/sample-page.html');
+    assertDatabaseHas('taxonomy_pages', ['slug' => 'sample-page']);
+});
+
+test('taxonomy page update regenerates html file', function () {
+    $page = TaxonomyPage::factory()->create(['slug' => 'update-page']);
+    Storage::disk('public')->assertExists('taxonomy-pages/update-page.html');
+
+    $page->update(['html' => '<p>updated</p>']);
+
+    Storage::disk('public')->assertExists('taxonomy-pages/update-page.html');
+    expect(Storage::disk('public')->get('taxonomy-pages/update-page.html'))->toContain('updated');
+});
+
+test('taxonomy page deletion removes html file', function () {
+    $page = TaxonomyPage::factory()->create(['slug' => 'delete-page']);
+    Storage::disk('public')->assertExists('taxonomy-pages/delete-page.html');
+
+    $page->delete();
+
+    Storage::disk('public')->assertMissing('taxonomy-pages/delete-page.html');
+    assertDatabaseMissing('taxonomy_pages', ['slug' => 'delete-page']);
+});
+
+test('taxonomy page resource serializes correctly', function () {
+    $page = TaxonomyPage::factory()->create(['slug' => 'res-page']);
+    $data = (new TaxonomyPageResource($page))->resolve();
+
+    expect($data['slug'])->toBe('res-page')
+        ->and($data['html'])->toBe($page->html);
+});


### PR DESCRIPTION
## Summary
- implement `TaxonomyPage` model and migration
- store HTML as static files when saved
- add rich text editing with CKEditor upload support
- provide Livewire form & table components
- expose `TaxonomyPageResource`
- serve pages via `/taxonomy/{slug}` route
- include Pest tests for page model

## Testing
- `vendor/bin/pest` *(fails: Parallel plugin missing and blocked network requests)*

------
https://chatgpt.com/codex/tasks/task_e_68598b29edbc8326a7764846170e4779