### PR TITLE
Improve taxonomy history diff comparison

### DIFF
--- a/app/Domains/Taxonomy/Models/TaxonomyTerm.php
+++ b/app/Domains/Taxonomy/Models/TaxonomyTerm.php
@@ -150,7 +150,7 @@ class TaxonomyTerm extends Model
             ->orderBy('code', 'asc');;
     }
 
-    public function getMetadata($code)
+    public function getFormattedMetadata($code)
     {
         if (is_array($this->metadata)) {
             foreach ($this->metadata as $item) {

--- a/app/Http/Controllers/Backend/TaxonomyController.php
+++ b/app/Http/Controllers/Backend/TaxonomyController.php
@@ -216,7 +216,7 @@ class TaxonomyController extends Controller
                 foreach ($activity['properties']['attributes'] as $field => $oldValue) {
                     $oldString = is_array($oldValue)
                         ? json_encode($oldValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
-                        : (string) ($newValue ?? '');
+                        : (string) ($oldValue ?? '');
 
                     $diffs[$field] = DiffHelper::calculate(
                         $oldString,

--- a/app/Http/Controllers/Backend/TaxonomyController.php
+++ b/app/Http/Controllers/Backend/TaxonomyController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers\Backend;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Auth;
+use Jfcherng\Diff\DiffHelper;
 use App\Http\Controllers\Controller;
 use App\Domains\Taxonomy\Models\Taxonomy;
 use App\Domains\Taxonomy\Models\TaxonomyTerm;
@@ -191,40 +192,43 @@ class TaxonomyController extends Controller
         // Convert activities collection to array
         $activities = $activities->toArray();
 
-        // TODO implement a better way to visualize the diff
-        // Highlight changes for JSON/list attributes in activity log
         foreach ($activities as &$activity) {
+            $diffs = [];
             if (isset($activity['properties']['attributes']) && isset($activity['properties']['old'])) {
-                // For each activity,
-                foreach ($activity['properties']['attributes'] as $key => $newValue) {
-                    //  For each attribute
-                    $oldValue = $activity['properties']['old'][$key] ?? null;
+                foreach ($activity['properties']['attributes'] as $field => $newValue) {
+                    $oldValue = $activity['properties']['old'][$field] ?? null;
 
-                    // If value is an array, compare and keep only show only the diff
-                    if (is_array($newValue) && is_array($oldValue)) {
-                        if (json_encode($newValue) == json_encode($oldValue)) {
-                            $activity['properties']['old'][$key] = "...";
-                            $activity['properties']['attributes'][$key] = "...";
-                        } else {
-                            // Iterate through each key in the new value
-                            foreach ($newValue as $subKey => $subValue) {
-                                // If the sub-value is different from the old value, highlight it
-                                if (array_key_exists($subKey, $oldValue)) {
-                                    if (json_encode($oldValue[$subKey]) == json_encode($subValue)) {
-                                        $activity['properties']['old'][$key][$subKey] = "...";
-                                        $activity['properties']['attributes'][$key][$subKey] = "...";
-                                    }
-                                }
-                            }
-                        }
+                    $oldString = is_array($oldValue)
+                        ? json_encode($oldValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+                        : (string) ($oldValue ?? '');
+                    $newString = is_array($newValue)
+                        ? json_encode($newValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+                        : (string) ($newValue ?? '');
+
+                    if ($oldString === $newString) {
+                        continue;
                     }
+
+                    $diffs[$field] = DiffHelper::calculate(
+                        $oldString,
+                        $newString,
+                        'Inline',
+                        [],
+                        [
+                            'detailLevel' => 'word',
+                            'resultForIdenticals' => '',
+                        ]
+                    );
                 }
             }
+
+            $activity['diffs'] = $diffs;
         }
 
         return view('backend.taxonomy.history', [
             'taxonomy'   => $taxonomy,
             'activities' => $activities,
+            'diffCss'    => DiffHelper::getStyleSheet(),
         ]);
     }
     /**

--- a/app/Http/Controllers/Backend/TaxonomyTermController.php
+++ b/app/Http/Controllers/Backend/TaxonomyTermController.php
@@ -9,7 +9,6 @@ use App\Http\Controllers\Controller;
 use App\Domains\Taxonomy\Models\Taxonomy;
 use App\Domains\Taxonomy\Models\TaxonomyTerm;
 use Carbon\Carbon;
-use phpDocumentor\Reflection\PseudoTypes\False_;
 use Spatie\Activitylog\Models\Activity;
 use Jfcherng\Diff\DiffHelper;
 

--- a/app/Http/Controllers/Backend/TaxonomyTermController.php
+++ b/app/Http/Controllers/Backend/TaxonomyTermController.php
@@ -10,6 +10,7 @@ use App\Domains\Taxonomy\Models\Taxonomy;
 use App\Domains\Taxonomy\Models\TaxonomyTerm;
 use phpDocumentor\Reflection\PseudoTypes\False_;
 use Spatie\Activitylog\Models\Activity;
+use Jfcherng\Diff\DiffHelper;
 
 class TaxonomyTermController extends Controller
 {
@@ -184,40 +185,69 @@ class TaxonomyTermController extends Controller
         $activities = $activities->toArray();
 
 
-        // TODO implement a better way to visualize the diff
-        // Highlight changes for JSON/list attributes in activity log
         foreach ($activities as &$activity) {
+            $diffs = [];
             if (isset($activity['properties']['attributes']) && isset($activity['properties']['old'])) {
-                // For each activity
-                $oldMetadata = array();
-                $newMetadata = array();
+                $attributes = $activity['properties']['attributes'];
+                $oldValues  = $activity['properties']['old'];
 
-                if (isset($activity['properties']['old']['metadata'])) {
-                    foreach ($activity['properties']['old']['metadata'] as $key => $item) {
-                        if (isset($item['code']) && isset($item['value'])) {
-                            $oldMetadata[$item['code']] = $item['value'] ?? null;
+                if (isset($oldValues['metadata'])) {
+                    $normalized = [];
+                    foreach ($oldValues['metadata'] as $item) {
+                        if (isset($item['code'])) {
+                            $normalized[$item['code']] = $item['value'] ?? null;
                         }
                     }
-                    ksort($oldMetadata);
-                    $activity['properties']['old']['metadata'] = $oldMetadata;
+                    ksort($normalized);
+                    $oldValues['metadata'] = $normalized;
                 }
 
-                if (isset($activity['properties']['attributes']['metadata'])) {
-                    foreach ($activity['properties']['attributes']['metadata'] as $key => $item) {
-                        if (isset($item['code']) && isset($item['value'])) {
-                            $newMetadata[$item['code']] = $item['value'] ?? null;
+                if (isset($attributes['metadata'])) {
+                    $normalized = [];
+                    foreach ($attributes['metadata'] as $item) {
+                        if (isset($item['code'])) {
+                            $normalized[$item['code']] = $item['value'] ?? null;
                         }
                     }
-                    ksort($newMetadata);
-                    $activity['properties']['attributes']['metadata'] = $newMetadata;
+                    ksort($normalized);
+                    $attributes['metadata'] = $normalized;
+                }
+
+                foreach ($attributes as $field => $newValue) {
+                    $oldValue = $oldValues[$field] ?? null;
+
+                    $oldString = is_array($oldValue)
+                        ? json_encode($oldValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+                        : (string) ($oldValue ?? '');
+                    $newString = is_array($newValue)
+                        ? json_encode($newValue, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+                        : (string) ($newValue ?? '');
+
+                    if ($oldString === $newString) {
+                        continue;
+                    }
+
+                    $diffs[$field] = DiffHelper::calculate(
+                        $oldString,
+                        $newString,
+                        'Inline',
+                        [],
+                        [
+                            'detailLevel' => 'word',
+                            'resultForIdenticals' => '',
+                        ]
+                    );
                 }
             }
+
+            $activity['diffs'] = $diffs;
         }
 
         return view('backend.taxonomy.terms.history', [
             'taxonomy'   => $taxonomy,
             'term'       => $term,
             'activities' => $activities,
+            'diffCss'    => DiffHelper::getStyleSheet(),
         ]);
     }
 }

--- a/app/Http/Controllers/Backend/TaxonomyTermController.php
+++ b/app/Http/Controllers/Backend/TaxonomyTermController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Controller;
 use App\Domains\Taxonomy\Models\Taxonomy;
 use App\Domains\Taxonomy\Models\TaxonomyTerm;
 use Carbon\Carbon;
+use Illuminate\Support\Facades\Config;
 use Spatie\Activitylog\Models\Activity;
 use Jfcherng\Diff\DiffHelper;
 
@@ -230,12 +231,9 @@ class TaxonomyTermController extends Controller
                     $diffs[$field] = DiffHelper::calculate(
                         $oldString,
                         $newString,
-                        'Inline',
-                        [],
-                        [
-                            'detailLevel' => 'word',
-                            'resultForIdenticals' => '',
-                        ]
+                        Config::get('diff-helper.renderer', 'Combined'),
+                        Config::get('diff-helper.calculate_options', []),
+                        Config::get('diff-helper.render_options', [])
                     );
                 }
             }

--- a/app/Http/Controllers/Backend/TaxonomyTermController.php
+++ b/app/Http/Controllers/Backend/TaxonomyTermController.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Facades\Auth;
 use App\Http\Controllers\Controller;
 use App\Domains\Taxonomy\Models\Taxonomy;
 use App\Domains\Taxonomy\Models\TaxonomyTerm;
+use Carbon\Carbon;
 use phpDocumentor\Reflection\PseudoTypes\False_;
 use Spatie\Activitylog\Models\Activity;
 use Jfcherng\Diff\DiffHelper;
@@ -241,6 +242,7 @@ class TaxonomyTermController extends Controller
             }
 
             $activity['diffs'] = $diffs;
+            $activity['created_at'] = Carbon::parse($activity['created_at'])->format('Y-m-d H:i');
         }
 
         return view('backend.taxonomy.terms.history', [

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "guzzlehttp/guzzle": "^7.0.1",
         "intervention/image": "^2.6",
         "jamesmills/laravel-timezone": "^1.9",
+        "jfcherng/php-diff": "^6.16",
         "lab404/laravel-impersonate": "^1.6",
         "langleyfoxall/laravel-nist-password-rules": "^6.0",
         "laravel/framework": "^8.54",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "968758f8754ba0b4f2981e1cdd4a9890",
+    "content-hash": "bb2b191e7f433cf802faba35af1588e8",
     "packages": [
         {
             "name": "arcanedev/log-viewer",
@@ -2193,6 +2193,243 @@
                 "source": "https://github.com/jamesmills/laravel-timezone/tree/1.13.0"
             },
             "time": "2023-02-17T11:07:53+00:00"
+        },
+        {
+            "name": "jfcherng/php-color-output",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jfcherng/php-color-output.git",
+                "reference": "6c7bf16686cc6a291647fcb87491640a2d5edd20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jfcherng/php-color-output/zipball/6c7bf16686cc6a291647fcb87491640a2d5edd20",
+                "reference": "6c7bf16686cc6a291647fcb87491640a2d5edd20",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.3"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^2.19",
+                "liip/rmt": "^1.6",
+                "phan/phan": "^2 || ^3 || ^4",
+                "phpunit/phpunit": ">=7 <10",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jfcherng\\Utility\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jack Cherng",
+                    "email": "jfcherng@gmail.com"
+                }
+            ],
+            "description": "Make your PHP command-line application colorful.",
+            "keywords": [
+                "ansi-colors",
+                "color",
+                "command-line",
+                "str-color"
+            ],
+            "support": {
+                "issues": "https://github.com/jfcherng/php-color-output/issues",
+                "source": "https://github.com/jfcherng/php-color-output/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/jfcherng/5usd",
+                    "type": "custom"
+                }
+            ],
+            "time": "2021-05-27T02:45:54+00:00"
+        },
+        {
+            "name": "jfcherng/php-diff",
+            "version": "6.16.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jfcherng/php-diff.git",
+                "reference": "7f46bcfc582e81769237d0b3f6b8a548efe8799d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jfcherng/php-diff/zipball/7f46bcfc582e81769237d0b3f6b8a548efe8799d",
+                "reference": "7f46bcfc582e81769237d0b3f6b8a548efe8799d",
+                "shasum": ""
+            },
+            "require": {
+                "jfcherng/php-color-output": "^3",
+                "jfcherng/php-mb-string": "^1.4.6 || ^2",
+                "jfcherng/php-sequence-matcher": "^3.2.10 || ^4",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.51",
+                "liip/rmt": "^1.6",
+                "phan/phan": "^5",
+                "phpunit/phpunit": "^9",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jfcherng\\Diff\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jack Cherng",
+                    "email": "jfcherng@gmail.com"
+                },
+                {
+                    "name": "Chris Boulton",
+                    "email": "chris.boulton@interspire.com"
+                }
+            ],
+            "description": "A comprehensive library for generating differences between two strings in multiple formats (unified, side by side HTML etc).",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/jfcherng/php-diff/issues",
+                "source": "https://github.com/jfcherng/php-diff/tree/6.16.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/jfcherng/5usd",
+                    "type": "custom"
+                }
+            ],
+            "time": "2024-03-10T17:40:29+00:00"
+        },
+        {
+            "name": "jfcherng/php-mb-string",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jfcherng/php-mb-string.git",
+                "reference": "8407bfefde47849c9e7c9594e6de2ac85a0f845d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jfcherng/php-mb-string/zipball/8407bfefde47849c9e7c9594e6de2ac85a0f845d",
+                "reference": "8407bfefde47849c9e7c9594e6de2ac85a0f845d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "phan/phan": "^5",
+                "phpunit/phpunit": "^9 || ^10"
+            },
+            "suggest": {
+                "ext-iconv": "Either \"ext-iconv\" or \"ext-mbstring\" is requried.",
+                "ext-mbstring": "Either \"ext-iconv\" or \"ext-mbstring\" is requried."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jfcherng\\Utility\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jack Cherng",
+                    "email": "jfcherng@gmail.com"
+                }
+            ],
+            "description": "A high performance multibytes sting implementation for frequently reading/writing operations.",
+            "support": {
+                "issues": "https://github.com/jfcherng/php-mb-string/issues",
+                "source": "https://github.com/jfcherng/php-mb-string/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/jfcherng/5usd",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-04-17T14:23:16+00:00"
+        },
+        {
+            "name": "jfcherng/php-sequence-matcher",
+            "version": "4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jfcherng/php-sequence-matcher.git",
+                "reference": "d2038ac29627340a7458609072a8ba355e80ec5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jfcherng/php-sequence-matcher/zipball/d2038ac29627340a7458609072a8ba355e80ec5b",
+                "reference": "d2038ac29627340a7458609072a8ba355e80ec5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3",
+                "phan/phan": "^5",
+                "phpunit/phpunit": "^9 || ^10",
+                "squizlabs/php_codesniffer": "^3.7"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Jfcherng\\Diff\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jack Cherng",
+                    "email": "jfcherng@gmail.com"
+                },
+                {
+                    "name": "Chris Boulton",
+                    "email": "chris.boulton@interspire.com"
+                }
+            ],
+            "description": "A longest sequence matcher. The logic is primarily based on the Python difflib package.",
+            "support": {
+                "issues": "https://github.com/jfcherng/php-sequence-matcher/issues",
+                "source": "https://github.com/jfcherng/php-sequence-matcher/tree/4.0.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/jfcherng/5usd",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-05-21T07:57:08+00:00"
         },
         {
             "name": "lab404/laravel-impersonate",
@@ -9850,16 +10087,16 @@
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.13.1",
+            "version": "1.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c"
+                "reference": "d25e62e636b0a9b01e3bdebb7823b474876dd829"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/1720ddd719e16cf0db4eb1c6eca108031636d46c",
-                "reference": "1720ddd719e16cf0db4eb1c6eca108031636d46c",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/d25e62e636b0a9b01e3bdebb7823b474876dd829",
+                "reference": "d25e62e636b0a9b01e3bdebb7823b474876dd829",
                 "shasum": ""
             },
             "require": {
@@ -9898,7 +10135,7 @@
             ],
             "support": {
                 "issues": "https://github.com/myclabs/DeepCopy/issues",
-                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.1"
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.2"
             },
             "funding": [
                 {
@@ -9906,7 +10143,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-04-29T12:36:36+00:00"
+            "time": "2025-07-04T14:07:32+00:00"
         },
         {
             "name": "nunomaduro/collision",
@@ -12593,5 +12830,5 @@
         "php": "^7.4|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/config/diff-helper.php
+++ b/config/diff-helper.php
@@ -18,7 +18,6 @@ return [
 
   'render_options' => [
     'detailLevel' => 'word',
-    'resultForIdenticals' => '',
     'lineNumbers' => true,
     'tabSize' => 4,
     'resultForIdenticals' => null,

--- a/config/diff-helper.php
+++ b/config/diff-helper.php
@@ -1,0 +1,26 @@
+<?php
+
+return [
+  // TEXT: Context, JsonText, Unified
+  // JSON: Combined, Inline, JsonHtml, SideBySide
+  'renderer' => 'Combined',
+
+
+  'calculate_options' => [
+    'context' => 3,
+    'ignoreCase' => false,
+    'ignoreLineEnding' => false,
+    'ignoreWhitespace' => false,
+    'lengthLimit' => 2000,
+    'fullContextIfIdentical' => false,
+  ],
+
+
+  'render_options' => [
+    'detailLevel' => 'word',
+    'resultForIdenticals' => '',
+    'lineNumbers' => true,
+    'tabSize' => 4,
+    'resultForIdenticals' => null,
+  ],
+];

--- a/resources/views/backend/taxonomy/history.blade.php
+++ b/resources/views/backend/taxonomy/history.blade.php
@@ -20,6 +20,7 @@
                             <tr>
                                 <th>{{ __('Date') }}</th>
                                 <th>{{ __('User') }}</th>
+                                <th>{{ __('Item') }}</th>
                                 <th>{{ __('Description') }}</th>
                                 <th>{{ __('Changes') }}</th>
                             </tr>
@@ -29,6 +30,15 @@
                                 <tr>
                                     <td>{{ $activity['created_at'] }}</td>
                                     <td>{{ $activity['causer']['name'] ?? 'System' }}</td>
+                                    <td>
+                                        @php
+                                            $subject = $activity['subject'];
+                                            $subjectName =
+                                                $subject['name'] ??
+                                                ($subject['file_name'] ?? '#' . $activity['subject_id']);
+                                        @endphp
+                                        {{ class_basename($activity['subject_type']) }}: {{ $subjectName }}
+                                    </td>
                                     <td>{{ $activity['description'] }}</td>
                                     <td>
                                         @if (!empty($activity['diffs']))

--- a/resources/views/backend/taxonomy/history.blade.php
+++ b/resources/views/backend/taxonomy/history.blade.php
@@ -3,9 +3,11 @@
 @section('title', __('Taxonomy History'))
 
 @section('content')
-@push('after-styles')
-    <style>{!! $diffCss !!}</style>
-@endpush
+    @push('after-styles')
+        <style>
+            {!! $diffCss !!}
+        </style>
+    @endpush
     <div class="container mt-4">
         <h3>{{ __('Change History for') }}: {{ $taxonomy->name }}</h3>
 
@@ -18,7 +20,6 @@
                             <tr>
                                 <th>{{ __('Date') }}</th>
                                 <th>{{ __('User') }}</th>
-                                <th>{{ __('Item') }}</th>
                                 <th>{{ __('Description') }}</th>
                                 <th>{{ __('Changes') }}</th>
                             </tr>
@@ -28,15 +29,6 @@
                                 <tr>
                                     <td>{{ $activity['created_at'] }}</td>
                                     <td>{{ $activity['causer']['name'] ?? 'System' }}</td>
-                                    <td>
-                                        @php
-                                            $subject = $activity['subject'];
-                                            $subjectName =
-                                                $subject['name'] ??
-                                                ($subject['file_name'] ?? '#' . $activity['subject_id']);
-                                        @endphp
-                                        {{ class_basename($activity['subject_type']) }}: {{ $subjectName }}
-                                    </td>
                                     <td>{{ $activity['description'] }}</td>
                                     <td>
                                         @if (!empty($activity['diffs']))

--- a/resources/views/backend/taxonomy/history.blade.php
+++ b/resources/views/backend/taxonomy/history.blade.php
@@ -3,6 +3,9 @@
 @section('title', __('Taxonomy History'))
 
 @section('content')
+@push('after-styles')
+    <style>{!! $diffCss !!}</style>
+@endpush
     <div class="container mt-4">
         <h3>{{ __('Change History for') }}: {{ $taxonomy->name }}</h3>
 
@@ -36,59 +39,13 @@
                                     </td>
                                     <td>{{ $activity['description'] }}</td>
                                     <td>
-                                        @if ($activity['properties']['attributes'] ?? false)
-                                            <ul class="mb-0 list-unstyled">
-                                                @foreach ($activity['properties']['attributes'] as $field => $new)
-                                                    @php $old = $activity['properties']['old'][$field] ?? null; @endphp
-                                                    <li>
-                                                        <strong>{{ $field }}</strong>:
-                                                        @if (is_bool($old) && is_bool($new))
-                                                            {{-- If boolean values  --}}
-                                                            {{ $old ? 1 : 0 }} &rarr; {{ $new ? 1 : 0 }}
-                                                        @elseif (is_array($old) || is_array($new))
-                                                            {{-- if arrays  --}}
-                                                            <div class="container">
-                                                                <div>
-                                                                    @if (is_array($old))
-                                                                        <ul class="mb-0 list-unstyled">
-                                                                            @foreach ($old as $key => $value)
-                                                                                @if ($value !== '...')
-                                                                                    <li>
-                                                                                        {{ is_array($value) ? json_encode($value) : $value }}
-                                                                                    </li>
-                                                                                @endif
-                                                                            @endforeach
-                                                                        </ul>
-                                                                    @else
-                                                                        {{ $old }}
-                                                                    @endif
-                                                                </div>
-                                                                <div>
-                                                                    &rarr;
-                                                                </div>
-                                                                <div>
-                                                                    @if (is_array($new))
-                                                                        <ul class="mb-0 list-unstyled">
-                                                                            @foreach ($new as $key => $value)
-                                                                                @if ($value !== '...')
-                                                                                    <li>
-                                                                                        {{ is_array($value) ? json_encode($value) : $value }}
-                                                                                    </li>
-                                                                                @endif
-                                                                            @endforeach
-                                                                        </ul>
-                                                                    @else
-                                                                        {{ $new }}
-                                                                    @endif
-                                                                </div>
-                                                            </div>
-                                                        @else
-                                                            {{-- otherwise  --}}
-                                                            {{ $old }} &rarr; {{ $new }}
-                                                        @endif
-                                                    </li>
-                                                @endforeach
-                                            </ul>
+                                        @if (!empty($activity['diffs']))
+                                            @foreach ($activity['diffs'] as $field => $diff)
+                                                <div class="mb-2">
+                                                    <strong>{{ $field }}</strong>:
+                                                    <div class="diff-wrapper">{!! $diff !!}</div>
+                                                </div>
+                                            @endforeach
                                         @endif
                                     </td>
                                 </tr>

--- a/resources/views/backend/taxonomy/terms/history.blade.php
+++ b/resources/views/backend/taxonomy/terms/history.blade.php
@@ -3,6 +3,9 @@
 @section('title', __('Taxonomy Term History'))
 
 @section('content')
+@push('after-styles')
+    <style>{!! $diffCss !!}</style>
+@endpush
     <div class="container mt-4">
         <h3>{{ __('Change History for') }}: {{ $term->name }}</h3>
 
@@ -26,34 +29,13 @@
                                     <td>{{ $activity['causer']['name'] ?? 'System' }}</td>
                                     <td>{{ $activity['description'] }}</td>
                                     <td>
-                                        @if ($activity['properties']['attributes'] ?? false)
-                                            <ul class="mb-0 list-unstyled">
-                                                @foreach ($activity['properties']['attributes'] as $field => $new)
-                                                    @php $old = $activity['properties']['old'][$field] ?? null; @endphp
-                                                    <li>
-                                                        <strong>{{ $field }}</strong>:
-                                                        @if (is_bool($old) && is_bool($new))
-                                                            {{-- If boolean values  --}}
-                                                            {{ $old ? 1 : 0 }} &rarr; {{ $new ? 1 : 0 }}
-                                                        @elseif (is_array($old) || is_array($new))
-                                                            <div class="container">
-                                                                <div>
-                                                                    {{ json_encode($old) }}
-                                                                </div>
-                                                                <div>
-                                                                    &rarr;
-                                                                </div>
-                                                                <div>
-                                                                    {{ json_encode($new) }}
-                                                                </div>
-                                                            </div>
-                                                        @else
-                                                            {{-- otherwise  --}}
-                                                            {{ $old }} &rarr; {{ $new }}
-                                                        @endif
-                                                    </li>
-                                                @endforeach
-                                            </ul>
+                                        @if (!empty($activity['diffs']))
+                                            @foreach ($activity['diffs'] as $field => $diff)
+                                                <div class="mb-2">
+                                                    <strong>{{ $field }}</strong>:
+                                                    <div class="diff-wrapper">{!! $diff !!}</div>
+                                                </div>
+                                            @endforeach
                                         @endif
                                     </td>
                                 </tr>

--- a/resources/views/backend/taxonomy/terms/history.blade.php
+++ b/resources/views/backend/taxonomy/terms/history.blade.php
@@ -3,9 +3,11 @@
 @section('title', __('Taxonomy Term History'))
 
 @section('content')
-@push('after-styles')
-    <style>{!! $diffCss !!}</style>
-@endpush
+    @push('after-styles')
+        <style>
+            {!! $diffCss !!}
+        </style>
+    @endpush
     <div class="container mt-4">
         <h3>{{ __('Change History for') }}: {{ $term->name }}</h3>
 

--- a/resources/views/livewire/backend/taxonomy-term-metadata.blade.php
+++ b/resources/views/livewire/backend/taxonomy-term-metadata.blade.php
@@ -1,7 +1,7 @@
 @php
     $value = null;
     if (!empty($property['code']) && $term) {
-        $value = $term->getMetadata($property['code']);
+        $value = $term->getFormattedMetadata($property['code']);
     }
 @endphp
 


### PR DESCRIPTION
## Summary
- use jfcherng/php-diff to compute diffs for taxonomy and term changes
- render HTML diffs in history views with default stylesheet
- update composer dependencies

## Testing
- `composer test` *(fails: Target [Illuminate\Contracts\Debug\ExceptionHandler] is not instantiable)*

------
https://chatgpt.com/codex/tasks/task_e_6868bc349ac4832683ba4b9ec32b9770