### PR TITLE
Upgrade to Bootstrap 5.3

### DIFF
--- a/config/livewire-tables.php
+++ b/config/livewire-tables.php
@@ -4,5 +4,5 @@ return [
     /**
      * Options: tailwind | bootstrap-4 | bootstrap-5.
      */
-    'theme' => 'bootstrap-4',
+    'theme' => 'bootstrap-5',
 ];

--- a/config/log-viewer.php
+++ b/config/log-viewer.php
@@ -40,7 +40,7 @@ return [
      |  Make your own theme by adding a folder to the views directory and specifying it here.
      */
 
-    'theme' => 'bootstrap-4',
+    'theme' => 'bootstrap-5',
 
     /* -----------------------------------------------------------------
      |  Route settings

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@popperjs/core": "^2.5.1",
         "alpinejs": "^3.14.8",
         "axios": "^1.7.7",
-        "bootstrap": "^4.5.0",
+        "bootstrap": "^5.3.0",
         "cross-env": "^7.0",
         "font-awesome": "^4.7.0",
         "jquery": "^3.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,8 +31,8 @@ importers:
         specifier: ^1.7.7
         version: 1.7.7
       bootstrap:
-        specifier: ^4.5.0
-        version: 4.6.2(jquery@3.7.1)(popper.js@1.16.1)
+        specifier: ^5.3.0
+        version: 5.3.7(@popperjs/core@2.11.8)
       cross-env:
         specifier: ^7.0
         version: 7.0.3
@@ -1084,11 +1084,10 @@ packages:
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
 
-  bootstrap@4.6.2:
-    resolution: {integrity: sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==}
+  bootstrap@5.3.7:
+    resolution: {integrity: sha512-7KgiD8UHjfcPBHEpDNg+zGz8L3LqR3GVwqZiBRFX04a1BCArZOz1r2kjly2HQ0WokqTO0v1nF+QAt8dsW4lKlw==}
     peerDependencies:
-      jquery: 1.9.1 - 3
-      popper.js: ^1.16.1
+      '@popperjs/core': ^2.11.8
 
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
@@ -4745,10 +4744,9 @@ snapshots:
 
   boolbase@1.0.0: {}
 
-  bootstrap@4.6.2(jquery@3.7.1)(popper.js@1.16.1):
+  bootstrap@5.3.7(@popperjs/core@2.11.8):
     dependencies:
-      jquery: 3.7.1
-      popper.js: 1.16.1
+      '@popperjs/core': 2.11.8
 
   brace-expansion@1.1.11:
     dependencies:

--- a/resources/js/bootstrap.js
+++ b/resources/js/bootstrap.js
@@ -8,7 +8,6 @@ window.Swal = require('sweetalert2');
  */
 
 try {
-    window.Popper = require('popper.js').default;
     window.$ = window.jQuery = require('jquery');
 
     require('bootstrap');

--- a/resources/js/plugins.js
+++ b/resources/js/plugins.js
@@ -104,7 +104,7 @@ $(function () {
     });
 
     // Remember tab on page load
-    $('a[data-toggle="tab"], a[data-toggle="pill"]').on('shown.bs.tab', function (e) {
+    $('a[data-bs-toggle="tab"], a[data-bs-toggle="pill"]').on('shown.bs.tab', function (e) {
         let hash = $(e.target).attr('href');
         history.pushState ? history.pushState(null, null, hash) : location.hash = hash;
     });
@@ -115,5 +115,5 @@ $(function () {
     }
 
     // Enable tooltips everywhere
-    $('[data-toggle="tooltip"]').tooltip();
+    $('[data-bs-toggle="tooltip"]').tooltip();
 });

--- a/resources/views/backend/announcements/index.blade.php
+++ b/resources/views/backend/announcements/index.blade.php
@@ -19,9 +19,7 @@
                 @if (session('Success'))
                     <div class="alert alert-success">
                         {{ session('Success') }}
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 @endif
 

--- a/resources/views/backend/auth/user/includes/2fa.blade.php
+++ b/resources/views/backend/auth/user/includes/2fa.blade.php
@@ -1,5 +1,5 @@
 @if ($user->hasTwoFactorEnabled())
-    <span class="badge badge-success" data-toggle="tooltip" title="{{ timezone()->convertToLocal($user->twoFactorAuth->enabled_at) }}">@lang('Yes')</span>
+    <span class="badge bg-success" data-bs-toggle="tooltip" title="{{ timezone()->convertToLocal($user->twoFactorAuth->enabled_at) }}">@lang('Yes')</span>
 @else
-    <span class="badge badge-danger">@lang('No')</span>
+    <span class="badge bg-danger">@lang('No')</span>
 @endif

--- a/resources/views/backend/auth/user/includes/actions.blade.php
+++ b/resources/views/backend/auth/user/includes/actions.blade.php
@@ -29,7 +29,7 @@
         @if ($user->isMasterAdmin() && $logged_in_user->isMasterAdmin())
             <div class="dropdown d-inline-block">
                 <a class="btn btn-sm btn-secondary dropdown-toggle" id="moreMenuLink" href="#" role="button"
-                    data-toggle="dropdown" data-boundary="window" aria-haspopup="true" aria-expanded="false">
+                    data-bs-toggle="dropdown" data-bs-boundary="window" aria-haspopup="true" aria-expanded="false">
                     @lang('More')
                 </a>
 
@@ -49,7 +49,7 @@
                     $logged_in_user->can('admin.access.user.deactivate')))
             <div class="dropdown d-inline-block">
                 <a class="btn btn-sm btn-secondary dropdown-toggle" id="moreMenuLink" href="#" role="button"
-                    data-toggle="dropdown" data-boundary="window" aria-haspopup="true" aria-expanded="false">
+                    data-bs-toggle="dropdown" data-bs-boundary="window" aria-haspopup="true" aria-expanded="false">
                     @lang('More')
                 </a>
 

--- a/resources/views/backend/auth/user/includes/status.blade.php
+++ b/resources/views/backend/auth/user/includes/status.blade.php
@@ -1,5 +1,5 @@
 @if($user->isActive())
-    <span class='badge badge-success'>@lang('Active')</span>
+    <span class='badge bg-success'>@lang('Active')</span>
 @else
-    <span class='badge badge-danger'>@lang('Inactive')</span>
+    <span class='badge bg-danger'>@lang('Inactive')</span>
 @endif

--- a/resources/views/backend/auth/user/includes/verified.blade.php
+++ b/resources/views/backend/auth/user/includes/verified.blade.php
@@ -1,5 +1,5 @@
 @if ($user->isVerified())
-    <span class="badge badge-success" data-toggle="tooltip" title="{{ timezone()->convertToLocal($user->email_verified_at) }}">@lang('Yes')</span>
+    <span class="badge bg-success" data-bs-toggle="tooltip" title="{{ timezone()->convertToLocal($user->email_verified_at) }}">@lang('Yes')</span>
 @else
-    <span class="badge badge-danger">@lang('No')</span>
+    <span class="badge bg-danger">@lang('No')</span>
 @endif

--- a/resources/views/backend/courses/index.blade.php
+++ b/resources/views/backend/courses/index.blade.php
@@ -18,9 +18,7 @@
                 @if (session('Success'))
                     <div class="alert alert-success">
                         {{ session('Success') }}
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 @endif
 

--- a/resources/views/backend/event/index.blade.php
+++ b/resources/views/backend/event/index.blade.php
@@ -18,9 +18,7 @@
                 @if (session('Success'))
                     <div class="alert alert-success">
                         {{ session('Success') }}
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 @endif
 

--- a/resources/views/backend/includes/header.blade.php
+++ b/resources/views/backend/includes/header.blade.php
@@ -16,16 +16,16 @@
         @if (config('boilerplate.locale.status') && count(config('boilerplate.locale.languages')) > 1)
             <li class="c-header-nav-item dropdown">
                 <x-utils.link :text="__(getLocaleName(app()->getLocale()))" class="c-header-nav-link dropdown-toggle"
-                    id="navbarDropdownLanguageLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" />
+                    id="navbarDropdownLanguageLink" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" />
 
                 @include('includes.partials.lang')
             </li>
         @endif
     </ul>
 
-    <ul class="c-header-nav ml-auto mr-4">
+    <ul class="c-header-nav ms-auto me-4">
         <li class="c-header-nav-item dropdown">
-            <x-utils.link class="c-header-nav-link" data-toggle="dropdown" href="#" role="button"
+            <x-utils.link class="c-header-nav-link" data-bs-toggle="dropdown" href="#" role="button"
                 aria-haspopup="true" aria-expanded="false">
                 <x-slot name="text">
                     <div class="c-avatar">
@@ -35,7 +35,7 @@
                 </x-slot>
             </x-utils.link>
 
-            <div class="dropdown-menu dropdown-menu-right pt-0">
+            <div class="dropdown-menu dropdown-menu-end pt-0">
                 <div class="dropdown-header bg-light py-2">
                     <strong>
                         <!-- @lang('Account') -->
@@ -44,27 +44,27 @@
                 </div>
 
                 <x-utils.link class="dropdown-item" href="{{ route('dashboard.home') }}"
-                    icon="c-icon mr-2 fa fa-navicon">
+                    icon="c-icon me-2 fa fa-navicon">
                     <x-slot name="text">
                         Dashboard
                     </x-slot>
                 </x-utils.link>
 
                 <x-utils.link class="dropdown-item" href="{{ route('intranet.user.account') }}"
-                    icon="c-icon mr-2 fa fa-user">
+                    icon="c-icon me-2 fa fa-user">
                     <x-slot name="text">
                         Profile
                     </x-slot>
                 </x-utils.link>
 
                 <x-utils.link class="dropdown-item" href="{{ route('intranet.user.index') }}"
-                    icon="c-icon mr-2 fa fa-window-maximize">
+                    icon="c-icon me-2 fa fa-window-maximize">
                     <x-slot name="text">
                         Intranet
                     </x-slot>
                 </x-utils.link>
 
-                <x-utils.link class="dropdown-item" icon="c-icon mr-2 fa fa-sign-out"
+                <x-utils.link class="dropdown-item" icon="c-icon me-2 fa fa-sign-out"
                     onclick="event.preventDefault();document.getElementById('logout-form').submit();">
                     <x-slot name="text">
                         @lang('Logout')

--- a/resources/views/backend/news/index.blade.php
+++ b/resources/views/backend/news/index.blade.php
@@ -18,9 +18,7 @@
                 @if (session('Success'))
                     <div class="alert alert-success">
                         {{ session('Success') }}
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 @endif
 

--- a/resources/views/backend/semesters/index.blade.php
+++ b/resources/views/backend/semesters/index.blade.php
@@ -18,9 +18,7 @@
                 @if (session('Success'))
                     <div class="alert alert-success">
                         {{ session('Success') }}
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 @endif
 

--- a/resources/views/backend/taxonomy/index.blade.php
+++ b/resources/views/backend/taxonomy/index.blade.php
@@ -20,9 +20,7 @@
                 @if (session('Success'))
                     <div class="alert alert-success">
                         {{ session('Success') }}
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 @endif
 

--- a/resources/views/backend/taxonomy/terms/index.blade.php
+++ b/resources/views/backend/taxonomy/terms/index.blade.php
@@ -27,9 +27,7 @@
                 @if (session('Success'))
                     <div class="alert alert-success">
                         {{ session('Success') }}
-                        <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 @endif
 

--- a/resources/views/backend/taxonomy_file/index.blade.php
+++ b/resources/views/backend/taxonomy_file/index.blade.php
@@ -19,9 +19,7 @@
                 @if (session('Success'))
                     <div class="alert alert-success alert-dismissible fade show" role="alert">
                         {{ session('Success') }}
-                        <button type="button" class="close" data-dismiss="alert" aria-label="{{ __('Close') }}">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 @endif
 

--- a/resources/views/backend/taxonomy_page/index.blade.php
+++ b/resources/views/backend/taxonomy_page/index.blade.php
@@ -19,9 +19,7 @@
                 @if (session('Success'))
                     <div class="alert alert-success alert-dismissible fade show" role="alert">
                         {{ session('Success') }}
-                        <button type="button" class="close" data-dismiss="alert" aria-label="{{ __('Close') }}">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
+                        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
                     </div>
                 @endif
 

--- a/resources/views/components/utils/alert.blade.php
+++ b/resources/views/components/utils/alert.blade.php
@@ -2,9 +2,7 @@
 
 <div {{ $attributes->merge(['class' => 'alert alert-'.$type]) }} role="alert">
     @if ($dismissable)
-        <button type="button" class="close" data-dismiss="alert" aria-label="{{ $ariaLabel }}">
-            <span aria-hidden="true">&times;</span>
-        </button>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="{{ $ariaLabel }}"></button>
     @endif
 
     {{ $slot }}

--- a/resources/views/frontend/includes/nav.blade.php
+++ b/resources/views/frontend/includes/nav.blade.php
@@ -2,17 +2,17 @@
     <div class="container">
         <x-utils.link :href="route('frontend.index')" :text="appName()" class="navbar-brand" />
 
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent"
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent"
             aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="@lang('Toggle navigation')">
             <span class="navbar-toggler-icon"></span>
         </button>
 
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <ul class="navbar-nav ml-auto">
+            <ul class="navbar-nav ms-auto">
                 @if (config('boilerplate.locale.status') && count(config('boilerplate.locale.languages')) > 1)
                     <li class="nav-item dropdown">
                         <x-utils.link :text="__(getLocaleName(app()->getLocale()))" class="nav-link dropdown-toggle" id="navbarDropdownLanguageLink"
-                            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" />
+                            data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" />
 
                         @include('includes.partials.lang')
                     </li>
@@ -32,14 +32,14 @@
                 @else
                     <li class="nav-item dropdown">
                         <x-utils.link href="#" id="navbarDropdown" class="nav-link dropdown-toggle" role="button"
-                            data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
+                            data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" v-pre>
                             <x-slot name="text">
                                 <img class="rounded-circle" style="max-height: 20px" src="{{ $logged_in_user->avatar }}" />
                                 {{ $logged_in_user->name }} <span class="caret"></span>
                             </x-slot>
                         </x-utils.link>
 
-                        <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdown">
+                        <div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">
                             @if ($logged_in_user->isAdmin())
                                 <x-utils.link :href="route('dashboard.home')" :text="__('Dashboard')" class="dropdown-item" />
                             @endif

--- a/resources/views/frontend/user/account.blade.php
+++ b/resources/views/frontend/user/account.blade.php
@@ -14,19 +14,19 @@
                     <x-slot name="body">
                         <nav>
                             <div class="nav nav-tabs" id="nav-tab" role="tablist">
-                                <x-utils.link :text="__('My Profile')" class="nav-link active" id="my-profile-tab" data-toggle="pill"
+                                <x-utils.link :text="__('My Profile')" class="nav-link active" id="my-profile-tab" data-bs-toggle="pill"
                                     href="#my-profile" role="tab" aria-controls="my-profile" aria-selected="true" />
 
-                                <x-utils.link :text="__('Edit Information')" class="nav-link" id="information-tab" data-toggle="pill"
+                                <x-utils.link :text="__('Edit Information')" class="nav-link" id="information-tab" data-bs-toggle="pill"
                                     href="#information" role="tab" aria-controls="information" aria-selected="false" />
 
                                 @if (!$logged_in_user->isSocial())
-                                    <x-utils.link :text="__('Password')" class="nav-link" id="password-tab" data-toggle="pill"
+                                    <x-utils.link :text="__('Password')" class="nav-link" id="password-tab" data-bs-toggle="pill"
                                         href="#password" role="tab" aria-controls="password" aria-selected="false" />
                                 @endif
 
                                 <x-utils.link :text="__('Two Factor Authentication')" class="nav-link" id="two-factor-authentication-tab"
-                                    data-toggle="pill" href="#two-factor-authentication" role="tab"
+                                    data-bs-toggle="pill" href="#two-factor-authentication" role="tab"
                                     aria-controls="two-factor-authentication" aria-selected="false" />
                             </div>
                         </nav>

--- a/resources/views/includes/partials/lang.blade.php
+++ b/resources/views/includes/partials/lang.blade.php
@@ -1,4 +1,4 @@
-<div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarDropdownLanguageLink">
+<div class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdownLanguageLink">
     @foreach(collect(config('boilerplate.locale.languages'))->sortBy('name') as $code => $details)
         @if($code !== app()->getLocale())
             <x-utils.link class="dropdown-item pt-1 pb-1" :href="route('locale.change', $code)" :text="__(getLocaleName($code))" />


### PR DESCRIPTION
## Summary
- bump bootstrap from 4.5.0 to 5.3.0
- switch configs to bootstrap‑5 theme
- adjust JS to work with bootstrap 5
- update blade templates for new data attributes and classes

## Testing
- `pnpm install`
- `php artisan test` *(fails to finish in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_6880cca24fa48326b4c3a2dc77b73731